### PR TITLE
Improve uma model visibility handling (with vanilla armors and costumes)

### DIFF
--- a/src/main/java/net/tracen/umapyoi/client/model/UmaPlayerModel.java
+++ b/src/main/java/net/tracen/umapyoi/client/model/UmaPlayerModel.java
@@ -1,14 +1,9 @@
 package net.tracen.umapyoi.client.model;
 
-import java.util.List;
-
 import com.google.common.collect.Lists;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 
-import cn.mcmod_mmf.mmlib.client.model.BedrockHumanoidModel;
-import cn.mcmod_mmf.mmlib.client.model.bedrock.BedrockPart;
-import cn.mcmod_mmf.mmlib.client.model.pojo.BedrockModelPOJO;
 import net.minecraft.client.model.geom.ModelPart;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.util.Mth;
@@ -24,6 +19,12 @@ import net.tracen.umapyoi.registry.umadata.UmaData;
 import net.tracen.umapyoi.utils.ClientUtils;
 import net.tracen.umapyoi.utils.UmaSoulUtils;
 
+import java.util.List;
+
+import cn.mcmod_mmf.mmlib.client.model.BedrockHumanoidModel;
+import cn.mcmod_mmf.mmlib.client.model.bedrock.BedrockPart;
+import cn.mcmod_mmf.mmlib.client.model.pojo.BedrockModelPOJO;
+
 public class UmaPlayerModel<T extends LivingEntity> extends BedrockHumanoidModel<T> {
 
     public BedrockPart rightArmDown;
@@ -38,7 +39,7 @@ public class UmaPlayerModel<T extends LivingEntity> extends BedrockHumanoidModel
     public BedrockPart leftFoot;
     public BedrockPart rightLegHideParts;
     public BedrockPart leftLegHideParts;
-    public BedrockPart hat = new BedrockPart();
+    public BedrockPart hat;
     public BedrockPart hideParts;
     public BedrockPart tail;
     public BedrockPart tailDown;
@@ -65,21 +66,19 @@ public class UmaPlayerModel<T extends LivingEntity> extends BedrockHumanoidModel
         this.leftEar = this.getChild("left_ear");
         this.rightFoot = this.getChild("right_foot");
         this.leftFoot = this.getChild("left_foot");
-        this.hat = this.getChild("hat") != null ? this.getChild("hat") : new BedrockPart();
-        this.cape = this.getChild("cape") != null ? this.getChild("cape") : new BedrockPart();
-        this.hideParts = this.getChild("hide_parts") != null ? this.getChild("hide_parts") : new BedrockPart();
+        this.hat = this.getChild("hat");
+        this.cape = this.getChild("cape");
+        this.hideParts = this.getChild("hide_parts");
         this.rightEarHideParts = this.getChild("right_earmuffs");
         this.leftEarHideParts = this.getChild("left_earmuffs");
-        this.rightLegHideParts = this.getChild("right_leg_hide_parts") != null ? this.getChild("right_leg_hide_parts")
-                : new BedrockPart();
-        this.leftLegHideParts = this.getChild("left_leg_hide_parts") != null ? this.getChild("left_leg_hide_parts")
-                : new BedrockPart();
+        this.rightLegHideParts = this.getChild("right_leg_hide_parts");
+        this.leftLegHideParts = this.getChild("left_leg_hide_parts");
         this.tail = this.getChild("tail");
         this.tailDown = this.getChild("tail_down");
         this.longHairParts = Lists.newArrayList();
         this.getModelMap().forEach((name,part)->{
-        	if(name.startsWith("long_hair_") || name.equals("long_hair"))
-        		this.longHairParts.add(part);
+            if(name.startsWith("long_hair_") || name.equals("long_hair"))
+                this.longHairParts.add(part);
         });
     }
     
@@ -193,63 +192,34 @@ public class UmaPlayerModel<T extends LivingEntity> extends BedrockHumanoidModel
 
             this.crouching = player.isCrouching();
             if (UmapyoiConfig.VANILLA_ARMOR_RENDER.get() && !UmapyoiConfig.HIDE_PARTS_RENDER.get()) {
-                
-                if (!player.getItemBySlot(EquipmentSlot.HEAD).isEmpty()) {
-                    this.hideHat();
-                }else {
-                    this.showHat();
-                }
+                var noHelmet = player.getItemBySlot(EquipmentSlot.HEAD).isEmpty();
+                this.setHatAndEarsVisible(noHelmet, true);
 
-                if (!player.getItemBySlot(EquipmentSlot.CHEST).isEmpty()
-                        && !(player.getItemBySlot(EquipmentSlot.CHEST).getItem() instanceof ElytraItem)) {
-                    this.hideParts.visible = false;
-                    this.cape.visible = false;
-                }else {
-                    this.hideParts.visible = true;
-                    this.cape.visible = true;
-                }
+                var chestEquipment = player.getItemBySlot(EquipmentSlot.CHEST);
+                var noChestplate = chestEquipment.isEmpty() || (chestEquipment.getItem() instanceof ElytraItem);
+                this.hideParts.visible = noChestplate;
+                this.cape.visible = noChestplate;
 
-                if (!player.getItemBySlot(EquipmentSlot.LEGS).isEmpty()) {
-                    this.rightLegHideParts.visible = false;
-                    this.leftLegHideParts.visible = false;
-                }else {
-                    this.rightLegHideParts.visible = true;
-                    this.leftLegHideParts.visible = true;
-                }
+                var noLeggings = player.getItemBySlot(EquipmentSlot.LEGS).isEmpty();
+                this.rightLegHideParts.visible = noLeggings;
+                this.leftLegHideParts.visible = noLeggings;
 
-                if (!player.getItemBySlot(EquipmentSlot.FEET).isEmpty()) {
-                    this.rightFoot.visible = false;
-                    this.leftFoot.visible = false;
-                }else {
-                    this.rightFoot.visible = true;
-                    this.leftFoot.visible = true;
-                }
+                var noBoots = player.getItemBySlot(EquipmentSlot.FEET).isEmpty();
+                this.rightFoot.visible = noBoots;
+                this.leftFoot.visible = noBoots;
             }
-            
-            this.showEars();
         }
     }
 
-	public void showEars() {
-		if (this.hat.visible) {
-		    if (this.leftEarHideParts != null && !this.leftEarHideParts.isEmpty())
-		        this.leftEar.visible = false;
-		    if (this.rightEarHideParts != null && !this.rightEarHideParts.isEmpty())
-		        this.rightEar.visible = false;
-		} else {
-		    if (this.leftEarHideParts != null && !this.leftEarHideParts.isEmpty())
-		        this.leftEar.visible = true;
-		    if (this.rightEarHideParts != null && !this.rightEarHideParts.isEmpty())
-		        this.rightEar.visible = true;
-		}
-	}
-    
     @Override
-    public void setAllVisible(boolean pVisible) {
-        super.setAllVisible(pVisible);
-        this.hat.visible = pVisible;
-        this.cape.visible = pVisible;
-        this.tail.visible = pVisible;
+    public void setAllVisible(boolean visible) {
+        this.setHatAndEarsVisible(visible, visible);
+        this.setHeadVisible(visible);
+        this.setBodyVisible(visible);
+        this.setCapeVisible(visible);
+        this.setArmsVisible(visible);
+        this.setLegsVisible(visible);
+        this.setTailVisible(visible);
     }
 
     public void copyAnim(BedrockPart part, ModelPart old_part) {
@@ -273,12 +243,90 @@ public class UmaPlayerModel<T extends LivingEntity> extends BedrockHumanoidModel
         if (part == this.rightLeg)
             part.z -= 0.125F;
     }
-    
-    public void showHat() {
-        this.hat.visible = true;
+
+    /**
+     * Set the visibility of both the hat and the ears. Should be preferred over setting the
+     * hat's visibility directly to ensure that the correct ear parts are shown.
+     */
+    public void setHatAndEarsVisible(boolean hatVisible, boolean earsVisible) {
+        this.hat.visible = hatVisible;
+        setEarsVisible(earsVisible);
     }
-    
-    public void hideHat() {
-        this.hat.visible = false;
+
+    public void setEarsVisible(boolean visible) {
+        setLeftEarVisible(visible);
+        setRightEarVisible(visible);
+    }
+
+    public void setLeftEarVisible(boolean visible) {
+        this.leftEarHideParts.visible = visible;
+        // hide parts (earmuffs) are mounted to hat
+        this.leftEar.visible = visible && (!this.hat.visible || this.leftEarHideParts.isEmpty());
+    }
+
+    public void setRightEarVisible(boolean visible) {
+        this.rightEarHideParts.visible = visible;
+        // hide parts (earmuffs) are mounted to hat
+        this.rightEar.visible = visible && (!this.hat.visible || this.rightEarHideParts.isEmpty());
+    }
+
+    /**
+     * Set the visibility of the head and long hair parts.
+     */
+    public void setHeadVisible(boolean visible) {
+        this.head.visible = visible;
+        this.setLongHairPartsVisible(visible);
+    }
+
+    public void setBodyVisible(boolean visible) {
+        this.body.visible = visible;
+        this.hideParts.visible = visible;
+    }
+
+    public void setCapeVisible(boolean visible) {
+        this.cape.visible = visible;
+    }
+
+    public void setArmsVisible(boolean visible) {
+        setLeftArmVisible(visible);
+        setRightArmVisible(visible);
+    }
+
+    public void setLeftArmVisible(boolean visible) {
+        this.leftArm.visible = visible;
+        this.leftArmDown.visible = visible;
+    }
+
+    public void setRightArmVisible(boolean visible) {
+        this.rightArm.visible = visible;
+        this.rightArmDown.visible = visible;
+    }
+
+    public void setLegsVisible(boolean visible) {
+        setLeftLegVisible(visible);
+        setRightLegVisible(visible);
+    }
+
+    public void setLeftLegVisible(boolean visible) {
+        this.leftLeg.visible = visible;
+        this.leftLegDown.visible = visible;
+        this.leftLegHideParts.visible = visible;
+        this.leftFoot.visible = visible;
+    }
+
+    public void setRightLegVisible(boolean visible) {
+        this.rightLeg.visible = visible;
+        this.rightLegDown.visible = visible;
+        this.rightLegHideParts.visible = visible;
+        this.rightFoot.visible = visible;
+    }
+
+    public void setTailVisible(boolean visible) {
+        this.tail.visible = visible;
+        this.tailDown.visible = visible;
+    }
+
+    public void setLongHairPartsVisible(boolean visible) {
+        this.longHairParts.forEach(part -> part.visible = visible);
     }
 }

--- a/src/main/java/net/tracen/umapyoi/events/handler/ClientEvents.java
+++ b/src/main/java/net/tracen/umapyoi/events/handler/ClientEvents.java
@@ -1,127 +1,70 @@
 package net.tracen.umapyoi.events.handler;
 
-import java.util.Map;
-
-import com.google.common.collect.Maps;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 
-import cn.mcmod_mmf.mmlib.client.model.pojo.BedrockModelPOJO;
-import cn.mcmod_mmf.mmlib.utils.ClientUtil;
 import net.minecraft.client.model.EntityModel;
 import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.entity.EquipmentSlot;
-import net.minecraft.world.entity.EquipmentSlot.Type;
 import net.minecraft.world.entity.HumanoidArm;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.ElytraItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.RenderArmEvent;
 import net.minecraftforge.client.event.RenderLivingEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
-import net.tracen.umapyoi.UmapyoiConfig;
 import net.tracen.umapyoi.api.UmapyoiAPI;
 import net.tracen.umapyoi.client.model.UmaCostumeModelUtils;
 import net.tracen.umapyoi.client.model.UmaPlayerModel;
 import net.tracen.umapyoi.data.tag.UmapyoiCostumeDataTags;
-import net.tracen.umapyoi.data.tag.UmapyoiItemTags;
 import net.tracen.umapyoi.events.client.RenderingUmaSoulEvent;
 import net.tracen.umapyoi.item.UmaCostumeItem;
 import net.tracen.umapyoi.registry.cosmetics.CosmeticData;
 import net.tracen.umapyoi.utils.ClientUtils;
 import net.tracen.umapyoi.utils.UmaSoulUtils;
 
+import cn.mcmod_mmf.mmlib.client.model.pojo.BedrockModelPOJO;
+import cn.mcmod_mmf.mmlib.utils.ClientUtil;
+
 @Mod.EventBusSubscriber(value = Dist.CLIENT)
 public class ClientEvents {
-
-    private static Map<EquipmentSlot, ItemStack> armor;
 
     @SubscribeEvent
     public static void preUmaSoulRendering(RenderingUmaSoulEvent.Pre event) {
         LivingEntity entity = event.getWearer();
         var model = event.getModel();
-        boolean hideHair = false;
+
         if (UmapyoiAPI.isUmaSuitRendering(entity)) {
             model.setAllVisible(false);
-            model.head.visible = true;
-            model.tail.visible = true;
-            if(UmapyoiAPI.isUmaSuitHasHat(entity)) {
-        		ResourceLocation loc = UmaCostumeItem.getCostumeID(UmapyoiAPI.getUmaSuit(entity));
-        		var costumeData = ClientUtils.getClientCosmeticDataRegistry().getHolder(
-        				ResourceKey.create(CosmeticData.REGISTRY_KEY, loc)
-        		);
-        		if(costumeData.get().is(UmapyoiCostumeDataTags.HAT_HIDEHAIR)) {
-        			hideHair = true;
-        			model.longHairParts.forEach(part -> part.visible = false);
-            	}else {
-            		model.longHairParts.forEach(part -> part.visible = true);
-            	}
-            	model.hideHat();
+            model.setHeadVisible(true);
+            model.setTailVisible(true);
+            if (UmapyoiAPI.isUmaSuitHasHat(entity)) {
+                ResourceLocation loc = UmaCostumeItem.getCostumeID(UmapyoiAPI.getUmaSuit(entity));
+                var costumeData = ClientUtils.getClientCosmeticDataRegistry().getHolder(
+                        ResourceKey.create(CosmeticData.REGISTRY_KEY, loc)
+                );
+                if (costumeData.get().is(UmapyoiCostumeDataTags.HAT_HIDEHAIR)) {
+                    model.setLongHairPartsVisible(false);
+                }
+                model.setHatAndEarsVisible(false, true);
             }
             else {
-            	model.showHat();
-            	
+                model.setHatAndEarsVisible(true, true);
             }
-        } else {
-            model.setAllVisible(true);
         }
-		if(hideHair) {
-			model.longHairParts.forEach(part -> part.visible = false);
-    	}else {
-    		model.longHairParts.forEach(part -> part.visible = true);
-    	}
-        model.showEars();
     }
     
     @SubscribeEvent
     public static <T extends LivingEntity, M extends EntityModel<T>> void onPlayerRendering(RenderLivingEvent.Pre<T, M> event) {
-        LivingEntity player = event.getEntity();
-        ItemStack umasoul = UmapyoiAPI.getRenderingUmaSoul(event.getEntity());
-        if (!umasoul.isEmpty()) {
-        	if(event.getRenderer().getModel() instanceof HumanoidModel humanoid) {
+        ItemStack umaSoul = UmapyoiAPI.getRenderingUmaSoul(event.getEntity());
+        if (!umaSoul.isEmpty()) {
+        	if (event.getRenderer().getModel() instanceof HumanoidModel<?> humanoid) {
         		humanoid.setAllVisible(false);
-            if (!UmapyoiConfig.VANILLA_ARMOR_RENDER.get() && !umasoul.isEmpty()) {
-            	//TODO: 重写这个方法以适配不同实体
-            	
-                armor = Maps.newHashMap();
-
-            	for(EquipmentSlot slot : EquipmentSlot.values()) {
-            		if(slot.getType() == Type.HAND)
-            			continue;
-            		ItemStack itemBySlot = player.getItemBySlot(slot);
-					armor.put(slot, itemBySlot);
-					
-					boolean renderElytry = UmapyoiConfig.ELYTRA_RENDER.get()
-							&& itemBySlot.getItem() instanceof ElytraItem;
-					boolean shouldRender = itemBySlot.is(UmapyoiItemTags.SHOULD_RENDER);
-					if (renderElytry || shouldRender)
-						player.setItemSlot(slot, itemBySlot);
-					else
-						player.setItemSlot(slot, ItemStack.EMPTY);
-            	}
-            	
-            	}
             }
-        }
-    }
-
-    @SubscribeEvent
-    public static <T extends LivingEntity, M extends EntityModel<T>> void onPlayerRenderingPost(RenderLivingEvent.Post<T, M>  event) {
-    	LivingEntity player = event.getEntity();
-        ItemStack umasoul = UmapyoiAPI.getRenderingUmaSoul(event.getEntity());
-        if (!UmapyoiConfig.VANILLA_ARMOR_RENDER.get() && armor != null && !umasoul.isEmpty()) {
-        	for(EquipmentSlot slot : EquipmentSlot.values()) {
-        		if(slot.getType() == Type.HAND)
-        			continue;
-        		
-				player.setItemSlot(slot, armor.get(slot));
-        	}
         }
     }
 

--- a/src/main/java/net/tracen/umapyoi/mixin/client/ElytraLayerMixin.java
+++ b/src/main/java/net/tracen/umapyoi/mixin/client/ElytraLayerMixin.java
@@ -1,0 +1,41 @@
+package net.tracen.umapyoi.mixin.client;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.layers.ElytraLayer;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.tracen.umapyoi.UmapyoiConfig;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ElytraLayer.class)
+public class ElytraLayerMixin {
+    @Inject(method = "render", at = @At(value = "HEAD"), cancellable = true)
+    private void render(
+            PoseStack poseStack,
+            MultiBufferSource buffer,
+            int packedLight,
+            LivingEntity livingEntity,
+            float limbSwing,
+            float limbSwingAmount,
+            float partialTicks,
+            float ageInTicks,
+            float netHeadYaw,
+            float headPitch,
+            CallbackInfo ci
+    ) {
+        if (UmapyoiConfig.ELYTRA_RENDER.get()) return;
+
+        ItemStack itemBySlot = livingEntity.getItemBySlot(EquipmentSlot.CHEST);
+        if (itemBySlot.is(Items.ELYTRA)) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/net/tracen/umapyoi/mixin/client/HumanoidArmorLayerMixin.java
+++ b/src/main/java/net/tracen/umapyoi/mixin/client/HumanoidArmorLayerMixin.java
@@ -1,0 +1,39 @@
+package net.tracen.umapyoi.mixin.client;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+
+import net.minecraft.client.model.HumanoidModel;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ArmorItem;
+import net.minecraft.world.item.ItemStack;
+import net.tracen.umapyoi.UmapyoiConfig;
+import net.tracen.umapyoi.api.UmapyoiAPI;
+import net.tracen.umapyoi.data.tag.UmapyoiItemTags;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(HumanoidArmorLayer.class)
+public class HumanoidArmorLayerMixin {
+    @Inject(method = "renderArmorPiece", at = @At(value = "HEAD"), cancellable = true)
+    private void renderArmorPiece(PoseStack poseStack, MultiBufferSource buffer, LivingEntity entity,
+                                  EquipmentSlot slot, int packedLight, HumanoidModel<LivingEntity> model,
+                                  CallbackInfo ci) {
+        if (UmapyoiConfig.VANILLA_ARMOR_RENDER.get() || !(entity instanceof Player))
+            return;
+
+        ItemStack umaSoul = UmapyoiAPI.getRenderingUmaSoul(entity);
+        if (umaSoul.isEmpty()) return;
+
+        ItemStack itemBySlot = entity.getItemBySlot(slot);
+        if (itemBySlot.getItem() instanceof ArmorItem && !itemBySlot.is(UmapyoiItemTags.SHOULD_RENDER)) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/resources/umapyoi.mixins.json
+++ b/src/main/resources/umapyoi.mixins.json
@@ -8,7 +8,9 @@
     "PlayerFoodExhaustionMixin"
   ],
   "client": [
-    "client.ItemInHandLayerMixin"
+    "client.ItemInHandLayerMixin",
+    "client.HumanoidArmorLayerMixin",
+    "client.ElytraLayerMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Backported from Fabric ver.

This PR does 2 major things:
- UmaPlayerModel.setAllVisible now sets the visibility of all "known" parts (those that are defined within the class). All of the defined parts are prone to being hidden at some point, so it creates an inconsistency when they're hidden and never properly enabled again, even when using setAllVisible. As a bonus, the UmaPlayerModel class now has a more user-friendly API.
- Reimplemented vanilla armor handling. Instead of swapping out the equipment slots during player model rendering, use Mixins to actually block them from rendering without messing with the equipment slots.

Fixes these bugs:
- Helmets can now be equipped properly when used with some other mods.
- Uma no longer goes naked if you enable and disable VANILLA_ARMOR_RENDER in-game with armors equipped (using a config menu that could be added using the Configured mod). I wish I was joking :joy: