### PR TITLE
Fix incorrect event class for support card pedestals

### DIFF
--- a/src/main/java/net/tracen/umapyoi/block/entity/SilverSupportAlbumPedestalBlockEntity.java
+++ b/src/main/java/net/tracen/umapyoi/block/entity/SilverSupportAlbumPedestalBlockEntity.java
@@ -213,7 +213,7 @@ public class SilverSupportAlbumPedestalBlockEntity extends SyncedBlockEntity imp
         result.getOrCreateTag().putString("support_card", key.toString());
         result.getOrCreateTag().putString("ranking", registry.get(key).getGachaRanking().name().toLowerCase());
         result.getOrCreateTag().putInt("maxDamage", registry.get(key).getMaxDamage());
-        GachaEvent.UmaSoulGachaEvent evt = new GachaEvent.UmaSoulGachaEvent(getStoredItem(), keys, key, result, copyRand);
+        GachaEvent.SupportCardGachaEvent evt = new GachaEvent.SupportCardGachaEvent(getStoredItem(), keys, key, result, copyRand);
         MinecraftForge.EVENT_BUS.post(evt);
         return evt.getOutput();
     }

--- a/src/main/java/net/tracen/umapyoi/block/entity/SupportAlbumPedestalBlockEntity.java
+++ b/src/main/java/net/tracen/umapyoi/block/entity/SupportAlbumPedestalBlockEntity.java
@@ -213,7 +213,7 @@ public class SupportAlbumPedestalBlockEntity extends SyncedBlockEntity implement
         result.getOrCreateTag().putString("support_card", key.toString());
         result.getOrCreateTag().putString("ranking", registry.get(key).getGachaRanking().name().toLowerCase());
         result.getOrCreateTag().putInt("maxDamage", registry.get(key).getMaxDamage());
-        GachaEvent.UmaSoulGachaEvent evt = new GachaEvent.UmaSoulGachaEvent(getStoredItem(), keys, key, result, copyRand);
+        GachaEvent.SupportCardGachaEvent evt = new GachaEvent.SupportCardGachaEvent(getStoredItem(), keys, key, result, copyRand);
         MinecraftForge.EVENT_BUS.post(evt);
         return evt.getOutput();
     }


### PR DESCRIPTION
Uma soul gacha event was used instead of support card gacha event.